### PR TITLE
feat: add API usage stats endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -378,6 +378,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // API usage stats
+  app.get("/api/usage/stats", authenticateToken, async (req: AuthRequest, res) => {
+    try {
+      const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const usage = await storage.getApiUsageStats(req.user!.id, since);
+      res.json({
+        ideas: usage.ai_ideas || 0,
+        captions: usage.ai_captions || 0,
+        images: usage.ai_images || 0,
+      });
+    } catch (error) {
+      console.error("Get API usage stats error:", error);
+      res.status(500).json({
+        error: { code: "INTERNAL_ERROR", message: "API kullanım istatistikleri alınamadı" },
+      });
+    }
+  });
+
   // Integration routes (Zapier/Make webhook)
   app.use("/api/integrations", integrationRoutes);
 


### PR DESCRIPTION
## Summary
- expose per-endpoint API usage counts via `/api/usage/stats`
- add storage helper to aggregate API usage by endpoint

## Testing
- `npm run check` *(fails: Cannot redeclare exported variable 'default', missing modules, etc.)*
- `npx tsc server/routes.ts server/storage.ts --noEmit` *(fails: Module '@shared/schema' or its corresponding type declarations not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fa892b60c832d9d2e931484cfd09f