### PR TITLE
Add project roadmap and basic health endpoint

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,32 @@
+# SocialSparkAI Roadmap
+
+## Phase 1: Foundation & Infrastructure
+- [x] Add health check endpoint for API monitoring
+- [ ] Document environment setup (.env requirements)
+- [ ] Establish CI type-check script
+
+## Phase 2: AI Content Engine
+- [ ] Finalize OpenAI service integration for idea/caption/image generation
+- [ ] Create REST endpoints for ideas, captions, and images
+- [ ] Rate limiting and plan-based usage counts (Free 5/day, Pro 50/day)
+
+## Phase 3: Content Planning
+- [ ] Implement database schema for posts and content ideas
+- [ ] Build scheduling system with cron jobs
+- [ ] Visual calendar UI for planned posts
+
+## Phase 4: Social Platform Integrations
+- [ ] Zapier webhook integration for autoposting
+- [ ] Native integrations for Instagram, LinkedIn, X, TikTok
+- [ ] Per-platform caption optimization
+
+## Phase 5: Billing & Analytics
+- [ ] Iyzico payment flow (Pro upgrades)
+- [ ] Usage analytics dashboard
+- [ ] Admin panel for users, posts, subscriptions
+
+## Phase 6: Polishing & Testing
+- [ ] E2E testing of API routes
+- [ ] Frontend UX improvements and responsive design
+- [ ] Performance monitoring and error tracking
+

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Trust proxy for rate limiting
   app.set("trust proxy", 1);
 
+  // Basic health check for uptime monitoring
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true });
+  });
+
   // Auth routes with IP rate limiting
   app.use("/api/auth", ipRateLimit(10, 15)); // 10 requests per 15 minutes per IP
 


### PR DESCRIPTION
## Summary
- add comprehensive roadmap with phased plan
- implement `/api/health` endpoint for uptime checks

## Testing
- `npm run check`
- `OPENAI_API_KEY=dummy npm run dev` *(fails: Error: DATABASE_URL must be set. Did you forget to provision a database?)*

------
https://chatgpt.com/codex/tasks/task_e_689fc19cef9c832db8ee2654cfd4f4f6